### PR TITLE
Fix minor issues with build CBMC proofs.

### DIFF
--- a/test/cbmc/proofs/decodeFileBlock_Http/decodeFileBlock_Http_harness.c
+++ b/test/cbmc/proofs/decodeFileBlock_Http/decodeFileBlock_Http_harness.c
@@ -24,6 +24,9 @@
  * @file decodeFileBlock_Http_harness.c
  * @brief Implements the proof harness for decodeFileBlock_Http function.
  */
+
+#include <stdlib.h>
+
 /* Http interface includes. */
 #include "ota_http_private.h"
 
@@ -52,7 +55,7 @@ void decodeFileBlock_Http_harness()
     pBlockId = &blockId;
     pBlockSize = &blockSize;
 
-    pPayload = ( char ** ) malloc( sizeof( char * ) );
+    pPayload = ( uint8_t ** ) malloc( sizeof( char * ) );
 
     /* pPayload cannot point to NULL since it is always initialized in the ingestDataBlock function. */
     __CPROVER_assume( pPayload != NULL );

--- a/test/cbmc/proofs/stringBuilderUInt32Decimal/stringBuilderUInt32Decimal_harness.c
+++ b/test/cbmc/proofs/stringBuilderUInt32Decimal/stringBuilderUInt32Decimal_harness.c
@@ -5,6 +5,9 @@
  * @file stringBuilderUInt32Decimal_harness.c
  * @brief Implements the proof harness for stringBuilderUInt32Decimal function.
  */
+
+#include <stdlib.h>
+
 /* Include files required for mqtt interface. */
 #include "ota_mqtt_private.h"
 

--- a/test/cbmc/proofs/stringBuilderUInt32Hex/stringBuilderUInt32Hex_harness.c
+++ b/test/cbmc/proofs/stringBuilderUInt32Hex/stringBuilderUInt32Hex_harness.c
@@ -5,6 +5,9 @@
  * @file stringBuilderUInt32Hex_harness.c
  * @brief Implements the proof harness for stringBuilderUInt32Hex function.
  */
+
+#include <stdlib.h>
+
 /* Include files required for mqtt interface. */
 #include "ota_mqtt_private.h"
 

--- a/test/cbmc/proofs/subscribeToJobNotificationTopics/Makefile
+++ b/test/cbmc/proofs/subscribeToJobNotificationTopics/Makefile
@@ -8,6 +8,8 @@ HARNESS_FILE = $(HARNESS_ENTRY)
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
 PROOF_UID = subscribeToJobNotificationTopics
 
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_mqtt_c_stringBuilder
+
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 


### PR DESCRIPTION
This pull request fixes minor issues in the building of the proof.  One issue is a missing include stdlib.h to get the function declarations for malloc and free.  The OTA project may have a different include file to get those declarations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.